### PR TITLE
Allow optional runner register params, bump machine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN curl -LJO https://gitlab-runner-downloads.s3.amazonaws.com/v${version}/deb/g
 RUN dpkg -i gitlab-runner_amd64.deb
 
 # Install Docker Machine
-RUN curl -L https://github.com/docker/machine/releases/download/v0.13.0/docker-machine-`uname -s`-`uname -m` >/tmp/docker-machine && \
+RUN curl -L https://github.com/docker/machine/releases/download/v0.16.2/docker-machine-`uname -s`-`uname -m` >/tmp/docker-machine && \
 chmod +x /tmp/docker-machine && \
 cp /tmp/docker-machine /usr/local/bin/docker-machine
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,8 @@ gitlab-runner register --executor docker+machine \
 --docker-disable-cache \
 --machine-machine-driver "amazonec2" \
 --machine-machine-name "gitlab-%s" \
---request-concurrency 12
+--request-concurrency 12 \
+$ADDITIONAL_REGISTER_PARAMS
 
 # Start Runner
 gitlab-runner run

--- a/gitlab-runner-template.yml
+++ b/gitlab-runner-template.yml
@@ -54,6 +54,10 @@ Parameters:
   GitLabRegistrationToken:
     Type: String
     Description: The Gitlab runer registration token
+  AdditionalRegisterParams:
+    Type: String
+    Description: Optional parameters to be passed to gitlab-runner register
+    Default: ""
   DockerImage:
     Type: String
     Default: "docker:latest"
@@ -253,6 +257,7 @@ Resources:
           {"Name":"AWS_SSH_USER", "Value": 'ubuntu'},
           {"Name":"AWS_AMI", "Value": { "Fn::FindInMap" : [ "AWSAMIRegionMap", { "Ref" : "AWS::Region" }, "UBUNTU1804"]}},
           {"Name":"DOCKER_IMAGE", "Value": !Ref DockerImage},
+          {"Name":"ADDITIONAL_REGISTER_PARAMS", "Value": !Ref AdditionalRegisterParams},
           {"Name":"AWS_INSTANCE_TYPE", "Value": !Ref InstanceType},
           {"Name":"CACHE_TYPE", "Value": 's3'},
           {"Name":"CACHE_S3_ACCESS_KEY", "Value": !Ref iamAccessKey},


### PR DESCRIPTION
- Allow for passing in optional gitlab-runner register parameters as an environment variable.
  - This should allow for setting docker-machine to run on the private IP rather than public by passing something like `amazonec2-use-private-address=true` which then allows you to lock down the security group and mitigates https://github.com/woodjme/autoscaling-ec2-gitlab-runners-fargate/issues/2
  - You could also pass in options such as `--tag-list mytag` to register the runner with a specific ci tag. (fixes https://github.com/woodjme/autoscaling-ec2-gitlab-runners-fargate/issues/1)
- Bump docker-machine version to latest stable (v0.16.2)