### PR TITLE
Fix typo on additional register params env var

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ gitlab-runner register --executor docker+machine \
 --request-concurrency 12 \
 --machine-machine-options amazonec2-use-private-address \
 --machine-machine-options amazonec2-security-group=$AWS_SECURITY_GROUP \
-$ADDITIONAL_REGISTER_PARAM
+$ADDITIONAL_REGISTER_PARAMS
 
 # Native env var seems to be broken for security group
 


### PR DESCRIPTION
The feature introduced in PR #3 was good but it got broken in subsequent commit ee8f9b85571d9e20aa32a1fe496d4fdab1ef4a18. 