### PR TITLE
Many Improvements

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,19 @@ test:
   script:
     - cfn-lint -t gitlab-runner-template.yml
 
+dev-deploys3:
+  stage: deploy
+  before_script:
+    - pip install awscli
+  script:
+    - sed -i -e "s/\woodjme\/autoscaling-ec2-gitlab-runners-fargate:latest/woodjme\/autoscaling-ec2-gitlab-runners-fargate:dev/" gitlab-runner-template.yml
+    - aws s3 cp --acl public-read gitlab-runner-template.yml s3://${BUCKET_NAME}/${CI_COMMIT_REF_NAME}/gitlab-runner-template.yml
+  environment:
+    name: ${CI_COMMIT_REF_NAME}
+    url: https://${BUCKET_NAME}.s3-${AWS_DEFAULT_REGION}.amazonaws.com/${CI_COMMIT_REF_NAME}/gitlab-runner-template.yml
+  only: 
+   - dev
+
 deploys3:
   stage: deploy
   before_script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,20 +5,20 @@ ARG GITLAB_RUNNER_VERSION="12.8.0"
 ARG DOCKER_MACHINE_VERSION="0.16.2-gitlab.3"
 
 # Install deps
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends \
+	ca-certificates \
 	curl \
 	git \
-	dumb-init \
-	&& rm -rf /var/lib/apt/lists/*
-
-# Install Gitlab Runner
-RUN curl -LJO https://gitlab-runner-downloads.s3.amazonaws.com/v${GITLAB_RUNNER_VERSION}/deb/gitlab-runner_amd64.deb
-RUN dpkg -i gitlab-runner_amd64.deb
-
-# Install Docker Machine
-RUN curl -L https://gitlab-docker-machine-downloads.s3.amazonaws.com/v${DOCKER_MACHINE_VERSION}/docker-machine >/tmp/docker-machine && \
-	chmod +x /tmp/docker-machine && \
-	cp /tmp/docker-machine /usr/local/bin/docker-machine
+	dumb-init && \
+	# Decrease docker image size
+	rm -rf /var/lib/apt/lists/* && \
+	# Install Gitlab Runner
+	curl -LJO https://gitlab-runner-downloads.s3.amazonaws.com/v${GITLAB_RUNNER_VERSION}/deb/gitlab-runner_amd64.deb && \
+	dpkg -i gitlab-runner_amd64.deb && \
+	# Install Docker Machine
+	curl -L https://gitlab-docker-machine-downloads.s3.amazonaws.com/v${DOCKER_MACHINE_VERSION}/docker-machine > /usr/local/bin/docker-machine && \
+	chmod +x /usr/local/bin/docker-machine
 
 COPY ./entrypoint.sh ./entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ARG DOCKER_MACHINE_VERSION="0.16.2-gitlab.3"
 RUN apt-get update && apt-get install -y \
 	curl \
 	git \
+	dumb-init \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Install Gitlab Runner
@@ -22,4 +23,5 @@ RUN curl -L https://gitlab-docker-machine-downloads.s3.amazonaws.com/v${DOCKER_M
 COPY ./entrypoint.sh ./entrypoint.sh
 
 ENV REGISTER_NON_INTERACTIVE=true
-ENTRYPOINT [ "./entrypoint.sh" ]
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "./entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM ubuntu:bionic
 LABEL maintainer="me@jamiewood.io"
 
-ARG version="12.8.0"
+ARG GITLAB_RUNNER_VERSION="12.8.0"
+ARG DOCKER_MACHINE_VERSION="0.16.2-gitlab.3"
 
 # Install deps
 RUN apt-get update && apt-get install -y \
@@ -10,13 +11,13 @@ RUN apt-get update && apt-get install -y \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Install Gitlab Runner
-RUN curl -LJO https://gitlab-runner-downloads.s3.amazonaws.com/v${version}/deb/gitlab-runner_amd64.deb
+RUN curl -LJO https://gitlab-runner-downloads.s3.amazonaws.com/v${GITLAB_RUNNER_VERSION}/deb/gitlab-runner_amd64.deb
 RUN dpkg -i gitlab-runner_amd64.deb
 
 # Install Docker Machine
-RUN curl -L https://github.com/docker/machine/releases/download/v0.16.2/docker-machine-`uname -s`-`uname -m` >/tmp/docker-machine && \
-chmod +x /tmp/docker-machine && \
-cp /tmp/docker-machine /usr/local/bin/docker-machine
+RUN curl -L https://gitlab-docker-machine-downloads.s3.amazonaws.com/v${DOCKER_MACHINE_VERSION}/docker-machine >/tmp/docker-machine && \
+	chmod +x /tmp/docker-machine && \
+	cp /tmp/docker-machine /usr/local/bin/docker-machine
 
 COPY ./entrypoint.sh ./entrypoint.sh
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Always unregister runner on exit
+function gitlab-unregister {
+    gitlab-runner unregister --all-runners
+}
+
+trap 'gitlab-unregister' EXIT SIGHUP SIGINT SIGTERM
+
 # Define runner tags
 if [ -n "${RUNNER_TAG_LIST:-}" ]
 then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Define runner tags
+if [ -n "${RUNNER_TAG_LIST:-}" ]
+then
+    RUNNER_TAG_LIST_OPT=("--tag-list" "$RUNNER_TAG_LIST")
+else
+    RUNNER_TAG_LIST_OPT=("--run-untagged=true")
+fi
+
 # Register
 gitlab-runner register --executor docker+machine \
 --docker-privileged \
@@ -10,6 +18,7 @@ gitlab-runner register --executor docker+machine \
 --request-concurrency 12 \
 --machine-machine-options amazonec2-use-private-address \
 --machine-machine-options amazonec2-security-group=$AWS_SECURITY_GROUP \
+"${RUNNER_TAG_LIST_OPT[@]}" \
 $ADDITIONAL_REGISTER_PARAMS
 
 # Native env var seems to be broken for security group

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Set error handling
+set -euo pipefail
+
 # Always unregister runner on exit
 function gitlab-unregister {
     gitlab-runner unregister --all-runners

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,7 +33,7 @@ gitlab-runner register --executor docker+machine \
 --docker-disable-cache \
 --machine-machine-driver "amazonec2" \
 --machine-machine-name "gitlab-%s" \
---request-concurrency 12 \
+--request-concurrency "$RUNNER_REQUEST_CONCURRENCY" \
 --machine-machine-options amazonec2-use-private-address \
 --machine-machine-options amazonec2-security-group="$AWS_SECURITY_GROUP" \
 "${RUNNER_TAG_LIST_OPT[@]}" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,14 @@ else
     RUNNER_TAG_LIST_OPT=("--run-untagged=true")
 fi
 
+# Define adicional parameters
+if [ -n "${ADDITIONAL_REGISTER_PARAMS:-}" ]
+then
+    IFS=' ' read -r -a ADDITIONAL_REGISTER_PARAMS_OPT <<< "$ADDITIONAL_REGISTER_PARAMS"
+else
+    IFS=' ' read -r -a ADDITIONAL_REGISTER_PARAMS_OPT <<< ""
+fi
+
 # Register
 gitlab-runner register --executor docker+machine \
 --docker-privileged \
@@ -17,9 +25,9 @@ gitlab-runner register --executor docker+machine \
 --machine-machine-name "gitlab-%s" \
 --request-concurrency 12 \
 --machine-machine-options amazonec2-use-private-address \
---machine-machine-options amazonec2-security-group=$AWS_SECURITY_GROUP \
+--machine-machine-options amazonec2-security-group="$AWS_SECURITY_GROUP" \
 "${RUNNER_TAG_LIST_OPT[@]}" \
-$ADDITIONAL_REGISTER_PARAMS
+"${ADDITIONAL_REGISTER_PARAMS_OPT[@]}"
 
 # Native env var seems to be broken for security group
 

--- a/gitlab-runner-template.yml
+++ b/gitlab-runner-template.yml
@@ -55,6 +55,7 @@ Parameters:
   GitLabRegistrationToken:
     Type: String
     Description: The Gitlab runer registration token
+    NoEcho: true
   AdditionalRegisterParams:
     Type: String
     Description: Optional parameters to be passed to gitlab-runner register
@@ -156,6 +157,12 @@ Mappings:
 # Conditions:
 
 Resources:
+  gitLabRegistrationToken:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: gitLabRegistrationToken
+      Description: The Gitlab runer registration token
+      SecretString: !Ref GitLabRegistrationToken
   iamUser:
     Type: AWS::IAM::User
     Properties: 
@@ -198,6 +205,15 @@ Resources:
               - ecs-tasks.amazonaws.com
             Action:
               - 'sts:AssumeRole'
+      Policies:
+        - PolicyName: GitLabRegistrationToken
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'secretsmanager:DescribeSecret'
+                  - 'secretsmanager:GetSecretValue'
+                Resource: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:gitLabRegistrationToken-*'
   iamRoleForEcsTask:
     Type: AWS::IAM::Role
     Properties:
@@ -290,7 +306,6 @@ Resources:
         Image: woodjme/autoscaling-ec2-gitlab-runners-fargate:latest
         Environment: [
           {"Name":"CI_SERVER_URL", "Value": !Ref GitLabURL},
-          {"Name":"REGISTRATION_TOKEN", "Value": !Ref GitLabRegistrationToken},
           {"Name":"AWS_ROOT_SIZE", "Value": !Ref RootVolumeSize},
           {"Name":"AWS_DEFAULT_REGION", "Value": !Ref "AWS::Region"},
           {"Name":"AWS_VPC_ID", "Value": !Ref VpcId},
@@ -307,6 +322,9 @@ Resources:
           {"Name":"CACHE_S3_BUCKET_NAME", "Value": !Ref GitLabRunnerCacheBucket},
           {"Name":"CACHE_S3_BUCKET_LOCATION", "Value": !Ref "AWS::Region"},
           {"Name":"CACHE_S3_SERVER_ADDRESS", "Value": !Join ['', [s3., !Ref 'AWS::URLSuffix']]}
+        ]
+        Secrets: [
+          {"Name":"REGISTRATION_TOKEN", "ValueFrom": !Ref gitLabRegistrationToken}
         ]
         LogConfiguration:
           LogDriver: awslogs

--- a/gitlab-runner-template.yml
+++ b/gitlab-runner-template.yml
@@ -15,6 +15,7 @@ Metadata:
         Parameters:
           - GitLabURL
           - GitLabRegistrationToken
+          - RunnerTagList
           - AdditionalRegisterParams
       -
         Label:
@@ -56,6 +57,10 @@ Parameters:
     Type: String
     Description: The Gitlab runer registration token
     NoEcho: true
+  RunnerTagList:
+    Type: String
+    Description: Optional parameter to specify the gitlab-runner tags (Example "docker,aws")
+    Default: ""
   AdditionalRegisterParams:
     Type: String
     Description: Optional parameters to be passed to gitlab-runner register
@@ -321,7 +326,8 @@ Resources:
           {"Name":"CACHE_SHARED", "Value": "true"},
           {"Name":"CACHE_S3_BUCKET_NAME", "Value": !Ref GitLabRunnerCacheBucket},
           {"Name":"CACHE_S3_BUCKET_LOCATION", "Value": !Ref "AWS::Region"},
-          {"Name":"CACHE_S3_SERVER_ADDRESS", "Value": !Join ['', [s3., !Ref 'AWS::URLSuffix']]}
+          {"Name":"CACHE_S3_SERVER_ADDRESS", "Value": !Join ['', [s3., !Ref 'AWS::URLSuffix']]},
+          {"Name":"RUNNER_TAG_LIST", "Value": !Ref RunnerTagList}
         ]
         Secrets: [
           {"Name":"REGISTRATION_TOKEN", "ValueFrom": !Ref gitLabRegistrationToken}

--- a/gitlab-runner-template.yml
+++ b/gitlab-runner-template.yml
@@ -16,6 +16,7 @@ Metadata:
           - GitLabURL
           - GitLabRegistrationToken
           - RunnerTagList
+          - RunnerRequestConcurrency
           - AdditionalRegisterParams
       -
         Label:
@@ -57,6 +58,10 @@ Parameters:
     Type: String
     Description: The Gitlab runer registration token
     NoEcho: true
+  RunnerRequestConcurrency:
+    Type: Number
+    Description: Specify the number of concurrent EC2 virtual machines to spawn
+    Default: 12
   RunnerTagList:
     Type: String
     Description: Optional parameter to specify the gitlab-runner tags (Example "docker,aws")
@@ -327,6 +332,7 @@ Resources:
           {"Name":"CACHE_S3_BUCKET_NAME", "Value": !Ref GitLabRunnerCacheBucket},
           {"Name":"CACHE_S3_BUCKET_LOCATION", "Value": !Ref "AWS::Region"},
           {"Name":"CACHE_S3_SERVER_ADDRESS", "Value": !Join ['', [s3., !Ref 'AWS::URLSuffix']]},
+          {"Name":"RUNNER_REQUEST_CONCURRENCY", "Value": !Ref RunnerRequestConcurrency},
           {"Name":"RUNNER_TAG_LIST", "Value": !Ref RunnerTagList}
         ]
         Secrets: [

--- a/gitlab-runner-template.yml
+++ b/gitlab-runner-template.yml
@@ -1,32 +1,32 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: Autoscaling Gitlab Runners Spawned by Fargate
-Metadata: 
-  AWS::CloudFormation::Interface: 
-    ParameterGroups: 
-      - 
-        Label: 
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      -
+        Label:
           default: "Network Configuration"
-        Parameters: 
+        Parameters:
           - VpcId
           - SubnetId
-      - 
-        Label: 
+      -
+        Label:
           default: "GitLab Configuration"
-        Parameters: 
+        Parameters:
           - GitLabURL
           - GitLabRegistrationToken
           - AdditionalRegisterParams
-      - 
-        Label: 
+      -
+        Label:
           default: "GitLab Runner Configuration"
-        Parameters: 
+        Parameters:
           - InstanceType
           - RootVolumeSize
           - CacheExpirationInDays
-      - 
-        Label: 
+      -
+        Label:
           default: "Fargate Spawner Configuration"
-        Parameters: 
+        Parameters:
           - CPU
           - Memory
           - DockerImage
@@ -165,7 +165,7 @@ Resources:
       SecretString: !Ref GitLabRegistrationToken
   iamUser:
     Type: AWS::IAM::User
-    Properties: 
+    Properties:
       UserName: !Join ['-', [ !Ref 'AWS::StackName', s3user]]
       Policies:
         - PolicyName: GitLabCacheBucket
@@ -218,7 +218,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       RoleName: !Join ['-', [ !Ref 'AWS::StackName', GitlabECSTaskRole]]
-      ManagedPolicyArns: 
+      ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AmazonEC2FullAccess
       AssumeRolePolicyDocument:
         Version: 2012-10-17
@@ -231,19 +231,19 @@ Resources:
               - 'sts:AssumeRole'
   SpawnerSecurityGroup:
     Type: AWS::EC2::SecurityGroup
-    Properties: 
+    Properties:
       GroupDescription: GitlabSpawnerSecurityRules
       GroupName: !Join ['-', [ !Ref 'AWS::StackName', GitlabSpawnerSecurityRules]]
-      SecurityGroupEgress: 
+      SecurityGroupEgress:
         - IpProtocol: "-1"
           CidrIp: 0.0.0.0/0
       VpcId: !Ref VpcId
   RunnerSecurityGroup:
     Type: AWS::EC2::SecurityGroup
-    Properties: 
+    Properties:
       GroupDescription: GitlabRunnerSecurityRules
       GroupName: !Join ['-', [ !Ref 'AWS::StackName', GitlabRunnerSecurityRules]]
-      SecurityGroupIngress: 
+      SecurityGroupIngress:
         - IpProtocol: tcp
           FromPort: 22
           ToPort: 22
@@ -252,7 +252,7 @@ Resources:
           FromPort: 2376
           ToPort: 2376
           SourceSecurityGroupId: !GetAtt SpawnerSecurityGroup.GroupId
-      SecurityGroupEgress: 
+      SecurityGroupEgress:
         - IpProtocol: "-1"
           CidrIp: 0.0.0.0/0
       VpcId: !Ref VpcId

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,7 @@ The purpose of the CloudFormation template is to create a Fargate Service that m
 * `SubnetID` - Select subnets - Must be in the selected VPC!
 * `GitLabURL` - The Gitlab URL, change if self-hosted
 * `GitLabRegistrationToken` - The Gitlab runer registration token
+* `RunnerTagList` - Optional parameter to specify the gitlab-runner tags (Example "docker,aws")
 * `AdditionalRegisterParams` - Any additional parameters you want to pass to `gitlab-runner register`
 * `InstanceType` - The instance type of the runners
 * `RootVolumeSize` -The size of the root volume on the runners

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,7 @@ The purpose of the CloudFormation template is to create a Fargate Service that m
 * `SubnetID` - Select subnets - Must be in the selected VPC!
 * `GitLabURL` - The Gitlab URL, change if self-hosted
 * `GitLabRegistrationToken` - The Gitlab runer registration token
+* `RunnerRequestConcurrency` - Specify the number of concurrent EC2 virtual machines to spawn (defaults to 12)
 * `RunnerTagList` - Optional parameter to specify the gitlab-runner tags (Example "docker,aws")
 * `AdditionalRegisterParams` - Any additional parameters you want to pass to `gitlab-runner register`
 * `InstanceType` - The instance type of the runners


### PR DESCRIPTION
* Secure GitlabRegistrationToken with AWS Secrets Manager
* Add runner tag list option
* Update additional parameters on entrypoint
* Unregister gitlab-runner on exit
* Set error control in entrypoint
* Use docker machine version recommended by gitlab
* Add dumb-init to docker image
* Allow specifying the number of concurrent VMs to spawn